### PR TITLE
Initialise the rubocop extension

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,13 +1,3 @@
-AllCops:
-  TargetRubyVersion: 2.6
-
-Style/StringLiterals:
-  Enabled: true
-  EnforcedStyle: double_quotes
-
-Style/StringLiteralsInInterpolation:
-  Enabled: true
-  EnforcedStyle: double_quotes
-
-Layout/LineLength:
-  Max: 120
+Naming/FileName:
+ Exclude:
+   - lib/rubocop-solidus.rb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,58 @@
+PATH
+  remote: .
+  specs:
+    rubocop-solidus (0.1.0)
+      rubocop
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    diff-lcs (1.5.0)
+    json (2.6.3)
+    parallel (1.22.1)
+    parser (3.2.1.1)
+      ast (~> 2.4.1)
+    rainbow (3.1.1)
+    rake (13.0.6)
+    regexp_parser (2.7.0)
+    rexml (3.2.5)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.1)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.4)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
+    rubocop (1.48.1)
+      json (~> 2.3)
+      parallel (~> 1.10)
+      parser (>= 3.2.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.26.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.27.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (2.4.2)
+
+PLATFORMS
+  arm64-darwin-21
+
+DEPENDENCIES
+  rake (~> 13.0)
+  rspec (~> 3.0)
+  rubocop (~> 1.21)
+  rubocop-solidus!
+
+BUNDLED WITH
+   2.3.6

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ TODO: Delete this and the text above, and describe your gem
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'rubocop-solidus'
+gem 'rubocop-solidus', require: false
 ```
 
 And then execute:

--- a/Rakefile
+++ b/Rakefile
@@ -10,3 +10,28 @@ require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
 task default: %i[spec rubocop]
+
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec) do |spec|
+  spec.pattern = FileList['spec/**/*_spec.rb']
+end
+
+desc 'Generate a new cop with a template'
+task :new_cop, [:cop] do |_task, args|
+  require 'rubocop'
+
+  cop_name = args.fetch(:cop) do
+    warn 'usage: bundle exec rake new_cop[Department/Name]'
+    exit!
+  end
+
+  generator = RuboCop::Cop::Generator.new(cop_name)
+
+  generator.write_source
+  generator.write_spec
+  generator.inject_require(root_file_path: 'lib/rubocop/cop/solidus_cops.rb')
+  generator.inject_config(config_file_path: 'config/default.yml')
+
+  puts generator.todo
+end

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,0 +1,1 @@
+# Write it!

--- a/lib/rubocop-solidus.rb
+++ b/lib/rubocop-solidus.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+
+require_relative 'rubocop/solidus'
+require_relative 'rubocop/solidus/version'
+require_relative 'rubocop/solidus/inject'
+
+RuboCop::Solidus::Inject.defaults!
+
+require_relative 'rubocop/cop/solidus_cops'

--- a/lib/rubocop/cop/solidus_cops.rb
+++ b/lib/rubocop/cop/solidus_cops.rb
@@ -1,0 +1,1 @@
+# frozen_string_literal: true

--- a/lib/rubocop/solidus.rb
+++ b/lib/rubocop/solidus.rb
@@ -2,9 +2,15 @@
 
 require_relative "solidus/version"
 
-module Rubocop
+module RuboCop
   module Solidus
     class Error < StandardError; end
     # Your code goes here...
+    PROJECT_ROOT   = Pathname.new(__dir__).parent.parent.expand_path.freeze
+    CONFIG_DEFAULT = PROJECT_ROOT.join('config', 'default.yml').freeze
+    CONFIG         = YAML.safe_load(CONFIG_DEFAULT.read).freeze
+
+    private_constant(:CONFIG_DEFAULT, :PROJECT_ROOT)
   end
 end
+

--- a/lib/rubocop/solidus/inject.rb
+++ b/lib/rubocop/solidus/inject.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# The original code is from https://github.com/rubocop/rubocop-rspec/blob/master/lib/rubocop/rspec/inject.rb
+# See https://github.com/rubocop/rubocop-rspec/blob/master/MIT-LICENSE.md
+module RuboCop
+  module Solidus
+    # Because RuboCop doesn't yet support plugins, we have to monkey patch in a
+    # bit of our configuration.
+    module Inject
+      def self.defaults!
+        path = CONFIG_DEFAULT.to_s
+        hash = ConfigLoader.send(:load_yaml_configuration, path)
+        config = Config.new(hash, path).tap(&:make_excludes_absolute)
+        puts "configuration from #{path}" if ConfigLoader.debug?
+        config = ConfigLoader.merge_with_default(config, path)
+        ConfigLoader.instance_variable_set(:@default_configuration, config)
+      end
+    end
+  end
+end

--- a/lib/rubocop/solidus/version.rb
+++ b/lib/rubocop/solidus/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Rubocop
+module RuboCop
   module Solidus
     VERSION = "0.1.0"
   end

--- a/rubocop-solidus.gemspec
+++ b/rubocop-solidus.gemspec
@@ -4,21 +4,24 @@ require_relative "lib/rubocop/solidus/version"
 
 Gem::Specification.new do |spec|
   spec.name = "rubocop-solidus"
-  spec.version = Rubocop::Solidus::VERSION
+  spec.version = RuboCop::Solidus::VERSION
   spec.authors = ["piyushswain"]
   spec.email = ["piyush.swain3@gmail.com"]
 
-  spec.summary = "TODO: Write a short summary, because RubyGems requires one."
-  spec.description = "TODO: Write a longer description or delete this line."
-  spec.homepage = "TODO: Put your gem's website or public repo URL here."
+  spec.summary = "Automatic Solidus code style checking tool."
+  spec.description = <<~DESCRIPTION
+    Automatic Solidus code style checking tool.
+    A RuboCop extension focused on enforcing Solidus best practices and coding conventions.
+  DESCRIPTION
+  spec.homepage = "https://www.github.com/piyushswain/rubocop-solidus"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 2.6.0"
 
   spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
-  spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
+  spec.metadata["source_code_uri"] = "https://www.github.com/piyushswain/rubocop-solidus"
+  spec.metadata["changelog_uri"] = "https://www.github.com/piyushswain/rubocop-solidus"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -36,4 +39,7 @@ Gem::Specification.new do |spec|
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html
+
+  spec.add_runtime_dependency 'rubocop'
 end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
-require "rubocop/solidus"
+require 'rubocop-solidus'
+require 'rubocop/rspec/support'
 
 RSpec.configure do |config|
-  # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.include RuboCop::RSpec::ExpectOffense
 
-  # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
+  config.raise_errors_for_deprecations!
+  config.raise_on_warning = true
+  config.fail_if_no_examples = true
 
-  config.expect_with :rspec do |c|
-    c.syntax = :expect
-  end
+  config.order = :random
+  Kernel.srand config.seed
 end


### PR DESCRIPTION
This commit adds changes to initialise the extension.
- Initialises the engine and other reequirements for the gem.
- Modifies gemspec to allow it to be valid.
- The output of the `bundle install` command is also included in this commit.