### PR TITLE
Add cop for class eval

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,5 @@ gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 
 gem "rubocop", "~> 1.21"
+
+gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,11 +8,16 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    coderay (1.1.3)
     diff-lcs (1.5.0)
     json (2.6.3)
+    method_source (1.0.0)
     parallel (1.22.1)
     parser (3.2.1.1)
       ast (~> 2.4.1)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.7.0)
@@ -49,6 +54,7 @@ PLATFORMS
   arm64-darwin-21
 
 DEPENDENCIES
+  pry
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.21)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-solidus (0.1.0)
+    rubocop-solidus (0.1.1)
       rubocop
 
 GEM

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,1 +1,4 @@
-# Write it!
+Solidus/ClassEvalDecorator:
+  Description: 'Checks if Class.class_eval is being used in the code'
+  Enabled: true
+  VersionAdded: '0.1.1'

--- a/lib/rubocop/cop/solidus/class_eval_decorator.rb
+++ b/lib/rubocop/cop/solidus/class_eval_decorator.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Solidus
+      # TODO: Write cop description and example of bad / good code. For every
+      # `SupportedStyle` and unique configuration, there needs to be examples.
+      # Examples must have valid Ruby syntax. Do not use upticks.
+      #
+      #
+      # @example EnforcedStyle: SpreeClass
+      #   # Description of the `SpreeClass` style.
+      #
+      #   # bad
+      #   SpreeClass.class_eval do
+      #   .
+      #   .
+      #   end
+      #
+      #
+      #   # good
+      #   module SpreeClassDecorator
+      #   .
+      #   .
+      #   end
+      #
+      class ClassEvalDecorator < Base
+        MSG = "Do not use `class_eval` flag. Use a decorator module instead. Check this link for an example https://guides.solidus.io/cookbook/redefining-checkout-steps"
+
+        # TODO: Don't call `on_send` unless the method name is in this list
+        # If you don't need `on_send` in the cop you created, remove it.
+        RESTRICT_ON_SEND = %i[class_eval].freeze
+
+        # @!method on_class_eval?(node)
+        def_node_matcher :on_class_eval?, <<~PATTERN
+          (send  ($...) :class_eval)
+        PATTERN
+
+        def on_send(node)
+          return unless on_class_eval?(node)
+
+          add_offense(node)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/solidus_cops.rb
+++ b/lib/rubocop/cop/solidus_cops.rb
@@ -1,1 +1,3 @@
 # frozen_string_literal: true
+
+require_relative "solidus/class_eval_decorator"

--- a/lib/rubocop/solidus/version.rb
+++ b/lib/rubocop/solidus/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Solidus
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end

--- a/rubocop-solidus.gemspec
+++ b/rubocop-solidus.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   DESCRIPTION
   spec.homepage = "https://www.github.com/piyushswain/rubocop-solidus"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.4.0"
 
   spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
 

--- a/spec/rubocop/cop/solidus/class_eval_decorator_spec.rb
+++ b/spec/rubocop/cop/solidus/class_eval_decorator_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Solidus::ClassEvalDecorator, :config do
+  let(:config) { RuboCop::Config.new("Solidus/ClassEvalDecorator" => { "Enabled" => true }) }
+
+  it 'registers an offense when using `#bad_method`' do
+    expect_offense(<<~RUBY)
+      Product.class_eval do
+      ^^^^^^^^^^^^^^^^^^ Do not use `class_eval` flag. Use a decorator module instead. Check this link for an example https://guides.solidus.io/cookbook/redefining-checkout-steps\n
+      end
+
+    RUBY
+  end
+
+  it 'does not register an offense when using `#good_method`' do
+    expect_no_offenses(<<~RUBY)
+      module ProductDecorator
+      end
+    RUBY
+  end
+end

--- a/spec/rubocop/solidus_spec.rb
+++ b/spec/rubocop/solidus_spec.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe Rubocop::Solidus do
-  it "has a version number" do
-    expect(Rubocop::Solidus::VERSION).not_to be nil
-  end
-
-  it "does something useful" do
-    expect(false).to eq(true)
+RSpec.describe RuboCop::Solidus do
+  it 'has a version number' do
+    expect(RuboCop::Solidus::VERSION).not_to be nil
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'rubocop-solidus'
 require 'rubocop/rspec/support'
+require 'pry'
 
 RSpec.configure do |config|
   config.include RuboCop::RSpec::ExpectOffense


### PR DESCRIPTION
This PR adds the cop `Solidus/ClassEvalDecorator`.

Also the following changes have been made
- Added `binding.pry`
- Updated Gem version
- Added specs for the new cop
- Updated Ruby version requirement from 2.6 to 2.4